### PR TITLE
Fix pipeline diagram not rendering on GitHub

### DIFF
--- a/docs/pipeline.svg
+++ b/docs/pipeline.svg
@@ -61,7 +61,7 @@
   <!-- ── Input: E2E Test Artifacts ── -->
   <rect x="250" y="52" width="300" height="54" rx="8" fill="url(#input)" opacity="0.15" stroke="#6366f1" stroke-width="1.5"/>
   <text x="400" y="74" text-anchor="middle" fill="#a5b4fc" font-size="13" font-weight="600">E2E Test Artifacts</text>
-  <text x="400" y="94" text-anchor="middle" fill="#8b949e" font-size="11">screenshots/ &nbsp; videos/ &nbsp; summaries/</text>
+  <text x="400" y="94" text-anchor="middle" fill="#8b949e" font-size="11">screenshots/ &#160; videos/ &#160; summaries/</text>
 
   <!-- Arrow: Input → Stage 1 -->
   <line x1="400" y1="106" x2="400" y2="128" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arrow)"/>


### PR DESCRIPTION
## Summary
- Replace `&nbsp;` (HTML entity, invalid in XML) with `&#160;` (numeric character reference) in `docs/pipeline.svg`
- GitHub's SVG renderer uses strict XML parsing, and `&nbsp;` is not a predefined XML entity, causing the diagram to fail to render

## Test plan
- [ ] Verify the pipeline diagram renders correctly on the PR's README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)