### PR TITLE
Fix pipeline diagram rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Quorum sends your Playwright screenshots and video recordings to multiple AI vis
 
 ## How It Works
 
-<p align="center">
-  <img src="docs/pipeline.svg" alt="Quorum Pipeline Diagram" width="800">
-</p>
+<div align="center">
+
+![Quorum Pipeline Diagram](docs/pipeline.svg)
+
+</div>
 
 ## What Makes This Different
 


### PR DESCRIPTION
## Summary
- Switch from raw HTML `<img>` tag to markdown `![](url)` syntax for the pipeline diagram
- GitHub's markdown renderer proxies markdown images through its camo CDN, but raw HTML `<img>` tags resolve to `/raw/` URLs that redirect cross-origin to `raw.githubusercontent.com` and fail to load

## Test plan
- [x] Verified diagram renders on the branch README: https://github.com/dadcoachengineer/QuorumUX/tree/fix/pipeline-svg-rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)