### PR TITLE
Fix productization issues for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "./dist/types.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/types.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./types": {

--- a/src/models/openrouter.ts
+++ b/src/models/openrouter.ts
@@ -6,6 +6,13 @@
  */
 
 /**
+ * Redact OpenRouter API keys from error text to prevent leaking secrets in logs.
+ */
+function redactApiKey(text: string): string {
+  return text.replace(/sk-or-v1-[a-zA-Z0-9]+/g, 'sk-or-***').replace(/sk-or-[a-zA-Z0-9]+/g, 'sk-or-***');
+}
+
+/**
  * Parameters for OpenRouter API call
  */
 export interface OpenRouterParams {
@@ -93,7 +100,7 @@ export async function callOpenRouter(params: OpenRouterParams): Promise<OpenRout
       try {
         const errorJson = JSON.parse(errorText);
         if (errorJson.error?.message) {
-          errorMessage += ` - ${errorJson.error.message}`;
+          errorMessage += ` - ${redactApiKey(errorJson.error.message)}`;
         }
       } catch {
         // Use generic error if JSON parsing fails

--- a/src/pipeline/extract-frames.ts
+++ b/src/pipeline/extract-frames.ts
@@ -12,7 +12,33 @@ import { QuorumUXConfig } from '../types';
 import * as logger from '../utils/logger';
 import { ensureDir } from '../utils/files';
 
+/**
+ * Verify that ffmpeg and ImageMagick montage are installed before running Stage 1.
+ */
+function checkRequiredTools(): void {
+  const missing: string[] = [];
+
+  try {
+    execSync('which ffmpeg', { stdio: 'pipe' });
+  } catch {
+    missing.push('ffmpeg — install with: brew install ffmpeg');
+  }
+
+  try {
+    execSync('which montage', { stdio: 'pipe' });
+  } catch {
+    missing.push('montage (ImageMagick) — install with: brew install imagemagick');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required tools for Stage 1:\n  ${missing.join('\n  ')}`
+    );
+  }
+}
+
 export async function extractFrames(config: QuorumUXConfig, runDir: string): Promise<void> {
+  checkRequiredTools();
   logger.stage('Stage 1: Frame Extraction & Grid Generation');
 
   const framesDir = path.join(runDir, 'frames');


### PR DESCRIPTION
## Summary

- **Shebang**: Add `#!/usr/bin/env node` to `src/index.ts` so `npx quorumux` works when installed from npm
- **Type exports**: Re-export public types (`QuorumUXConfig`, `ModelConfig`, etc.) from `index.ts` and fix `exports["."].types` path in `package.json` to point at `dist/index.d.ts`
- **Config validation**: Add `validateConfig()` in `loadConfig()` that checks all required fields and reports every error at once (not one at a time)
- **API key redaction**: Strip `sk-or-*` patterns from OpenRouter error messages before they reach logs
- **Tool checks**: Verify `ffmpeg` and `montage` exist before Stage 1 runs, with clear install instructions if missing
- **main() guard**: Only run CLI when executed directly — importing the package for types no longer triggers the pipeline

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] `head -1 dist/index.js` shows `#!/usr/bin/env node`
- [x] `grep QuorumUXConfig dist/index.d.ts` shows re-exported types
- [ ] Manual: run `npx tsx src/index.ts --dry-run` to confirm CLI still works
- [ ] Manual: provide a config with missing fields to verify validation error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)