### PR TITLE
Add prepublishOnly build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

- Adds `"prepublishOnly": "npm run build"` to package.json so `npm publish` always rebuilds `dist/` first, preventing stale artifacts from shipping

## Test plan

- [x] `npm pack --dry-run` still produces clean output

🤖 Generated with [Claude Code](https://claude.com/claude-code)