### PR TITLE
Add unit test suite with vitest (72 tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,12 @@
         "tsx": "^4.19.0"
       },
       "bin": {
-        "quorum": "dist/index.js"
+        "quorumux": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "typescript": "^5.6.0"
+        "typescript": "^5.6.0",
+        "vitest": "^4.0.18"
       },
       "engines": {
         "node": ">=18"
@@ -438,6 +439,395 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -447,6 +837,144 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -489,6 +1017,44 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -515,6 +1081,102 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -522,6 +1184,126 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tsx": {
@@ -563,6 +1345,176 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build"
@@ -59,7 +61,8 @@
     "tsx": "^4.19.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.6.0",
-    "@types/node": "^22.0.0"
+    "vitest": "^4.0.18"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { parseArgs, validateConfig } from './index';
+
+// ─── parseArgs ──────────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('returns defaults with no args', () => {
+    const result = parseArgs([]);
+    expect(result.config).toBe('./quorumux.config.ts');
+    expect(result.help).toBeUndefined();
+    expect(result.dryRun).toBeUndefined();
+    expect(result.verbose).toBeUndefined();
+    expect(result.skipVideo).toBeUndefined();
+    expect(result.startStage).toBeUndefined();
+    expect(result.runDir).toBeUndefined();
+  });
+
+  it('parses --help', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+  });
+
+  it('parses --dry-run', () => {
+    expect(parseArgs(['--dry-run']).dryRun).toBe(true);
+  });
+
+  it('parses --verbose', () => {
+    expect(parseArgs(['--verbose']).verbose).toBe(true);
+  });
+
+  it('parses --skip-video', () => {
+    expect(parseArgs(['--skip-video']).skipVideo).toBe(true);
+  });
+
+  it('parses --config', () => {
+    expect(parseArgs(['--config', 'my.config.ts']).config).toBe('my.config.ts');
+  });
+
+  it('parses --run-dir', () => {
+    expect(parseArgs(['--run-dir', '/tmp/run']).runDir).toBe('/tmp/run');
+  });
+
+  it('parses --start-stage 1', () => {
+    expect(parseArgs(['--start-stage', '1']).startStage).toBe(1);
+  });
+
+  it('parses --start-stage 4', () => {
+    expect(parseArgs(['--start-stage', '4']).startStage).toBe(4);
+  });
+
+  it('throws on invalid start-stage', () => {
+    expect(() => parseArgs(['--start-stage', '0'])).toThrow('--start-stage must be 1, 2, 3, or 4');
+    expect(() => parseArgs(['--start-stage', '5'])).toThrow('--start-stage must be 1, 2, 3, or 4');
+    expect(() => parseArgs(['--start-stage', 'abc'])).toThrow('--start-stage must be 1, 2, 3, or 4');
+  });
+
+  it('throws on unknown option', () => {
+    expect(() => parseArgs(['--bogus'])).toThrow('Unknown option: --bogus');
+  });
+
+  it('handles combined flags', () => {
+    const result = parseArgs(['--dry-run', '--verbose', '--skip-video', '--start-stage', '3']);
+    expect(result.dryRun).toBe(true);
+    expect(result.verbose).toBe(true);
+    expect(result.skipVideo).toBe(true);
+    expect(result.startStage).toBe(3);
+  });
+});
+
+// ─── validateConfig ─────────────────────────────────────────────────────────
+
+describe('validateConfig', () => {
+  function validConfig() {
+    return {
+      name: 'Test Project',
+      description: 'A test',
+      domain: 'testing',
+      appUrl: 'https://example.com',
+      userJourney: 'Sign up and use',
+      artifactsDir: './artifacts',
+      models: {
+        screenshot: [{ id: 'model/a', name: 'A' }],
+        video: { id: 'model/v', name: 'V' },
+        synthesis: { id: 'model/s', name: 'S' },
+      },
+    };
+  }
+
+  it('accepts a valid config', () => {
+    expect(() => validateConfig(validConfig())).not.toThrow();
+  });
+
+  for (const field of ['name', 'description', 'domain', 'appUrl', 'userJourney', 'artifactsDir'] as const) {
+    it(`rejects missing "${field}"`, () => {
+      const config = validConfig();
+      delete (config as any)[field];
+      expect(() => validateConfig(config)).toThrow(`"${field}" must be a non-empty string`);
+    });
+
+    it(`rejects empty "${field}"`, () => {
+      const config = validConfig();
+      (config as any)[field] = '';
+      expect(() => validateConfig(config)).toThrow(`"${field}" must be a non-empty string`);
+    });
+  }
+
+  it('rejects whitespace-only string fields', () => {
+    const config = validConfig();
+    config.name = '   ';
+    expect(() => validateConfig(config)).toThrow('"name" must be a non-empty string');
+  });
+
+  it('rejects missing models', () => {
+    const config = validConfig();
+    delete (config as any).models;
+    expect(() => validateConfig(config)).toThrow('"models" is required');
+  });
+
+  it('rejects empty screenshot array', () => {
+    const config = validConfig();
+    config.models.screenshot = [];
+    expect(() => validateConfig(config)).toThrow('"models.screenshot" must be an array with at least 1 entry');
+  });
+
+  it('rejects screenshot entry missing id or name', () => {
+    const config = validConfig();
+    config.models.screenshot = [{ id: '', name: '' }];
+    expect(() => validateConfig(config)).toThrow('"models.screenshot[0]" must have "id" and "name"');
+  });
+
+  it('rejects video missing id or name', () => {
+    const config = validConfig();
+    config.models.video = { id: '', name: '' };
+    expect(() => validateConfig(config)).toThrow('"models.video" must have "id" and "name"');
+  });
+
+  it('rejects synthesis missing id or name', () => {
+    const config = validConfig();
+    config.models.synthesis = { id: '', name: '' };
+    expect(() => validateConfig(config)).toThrow('"models.synthesis" must have "id" and "name"');
+  });
+
+  it('collects multiple errors at once', () => {
+    const config = { models: { screenshot: [] } };
+    try {
+      validateConfig(config);
+      expect.unreachable('should have thrown');
+    } catch (e: any) {
+      // Should contain errors for all 6 required string fields + screenshot array + video + synthesis
+      expect(e.message).toContain('"name"');
+      expect(e.message).toContain('"description"');
+      expect(e.message).toContain('"models.screenshot"');
+    }
+  });
+
+  it('tolerates extra fields', () => {
+    const config = { ...validConfig(), extraField: 'hello', another: 42 };
+    expect(() => validateConfig(config)).not.toThrow();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ function dryRun(config: QuorumUXConfig, runDir: string, options: PipelineOptions
 /**
  * Parse command-line arguments
  */
-function parseArgs(args: string[]): PipelineOptions & { help?: boolean } {
+export function parseArgs(args: string[]): PipelineOptions & { help?: boolean } {
   const options: any = {
     config: './quorumux.config.ts',
   };
@@ -338,7 +338,7 @@ async function loadConfig(configPath: string): Promise<QuorumUXConfig> {
 /**
  * Validate config has all required fields. Throws with all errors at once.
  */
-function validateConfig(config: any): void {
+export function validateConfig(config: any): void {
   const errors: string[] = [];
 
   for (const field of ['name', 'description', 'domain', 'appUrl', 'userJourney', 'artifactsDir'] as const) {

--- a/src/models/openrouter.test.ts
+++ b/src/models/openrouter.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { redactApiKey } from './openrouter';
+
+describe('redactApiKey', () => {
+  it('redacts sk-or-v1-* keys', () => {
+    expect(redactApiKey('key is sk-or-v1-abc123def456')).toBe('key is sk-or-***');
+  });
+
+  it('redacts sk-or-* keys', () => {
+    expect(redactApiKey('key is sk-or-abc123')).toBe('key is sk-or-***');
+  });
+
+  it('redacts multiple keys in one string', () => {
+    const input = 'first sk-or-v1-aaa then sk-or-bbb end';
+    expect(redactApiKey(input)).toBe('first sk-or-*** then sk-or-*** end');
+  });
+
+  it('leaves strings without keys unchanged', () => {
+    expect(redactApiKey('no keys here')).toBe('no keys here');
+  });
+
+  it('handles empty string', () => {
+    expect(redactApiKey('')).toBe('');
+  });
+});

--- a/src/models/openrouter.ts
+++ b/src/models/openrouter.ts
@@ -8,7 +8,7 @@
 /**
  * Redact OpenRouter API keys from error text to prevent leaking secrets in logs.
  */
-function redactApiKey(text: string): string {
+export function redactApiKey(text: string): string {
   return text.replace(/sk-or-v1-[a-zA-Z0-9]+/g, 'sk-or-***').replace(/sk-or-[a-zA-Z0-9]+/g, 'sk-or-***');
 }
 

--- a/src/personas/archetypes.test.ts
+++ b/src/personas/archetypes.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { ARCHETYPES } from './archetypes';
+
+describe('ARCHETYPES', () => {
+  it('has exactly 10 archetypes', () => {
+    expect(ARCHETYPES).toHaveLength(10);
+  });
+
+  it('all have required fields', () => {
+    for (const a of ARCHETYPES) {
+      expect(a.id).toBeTypeOf('string');
+      expect(a.name).toBeTypeOf('string');
+      expect(a.description).toBeTypeOf('string');
+      expect(a.device).toBeTypeOf('string');
+      expect(a.viewport).toBeDefined();
+      expect(a.behaviorNotes).toBeTypeOf('string');
+    }
+  });
+
+  it('all IDs are unique', () => {
+    const ids = ARCHETYPES.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('all IDs are kebab-case', () => {
+    for (const a of ARCHETYPES) {
+      expect(a.id).toMatch(/^[a-z]+(-[a-z]+)*$/);
+    }
+  });
+
+  it('viewport dimensions are positive integers', () => {
+    for (const a of ARCHETYPES) {
+      expect(Number.isInteger(a.viewport.width)).toBe(true);
+      expect(Number.isInteger(a.viewport.height)).toBe(true);
+      expect(a.viewport.width).toBeGreaterThan(0);
+      expect(a.viewport.height).toBeGreaterThan(0);
+    }
+  });
+
+  it('device values are valid', () => {
+    const validDevices = new Set(['desktop', 'mobile', 'tablet']);
+    for (const a of ARCHETYPES) {
+      expect(validDevices.has(a.device)).toBe(true);
+    }
+  });
+
+  it('mobile-first has mobile device', () => {
+    const mobileFirst = ARCHETYPES.find((a) => a.id === 'mobile-first');
+    expect(mobileFirst).toBeDefined();
+    expect(mobileFirst!.device).toBe('mobile');
+  });
+
+  it('accessibility archetype has accessibilityNeeds', () => {
+    const a11y = ARCHETYPES.find((a) => a.id === 'accessibility');
+    expect(a11y).toBeDefined();
+    expect(a11y!.accessibilityNeeds).toBeDefined();
+    expect(a11y!.accessibilityNeeds!.length).toBeGreaterThan(0);
+  });
+});

--- a/src/personas/index.test.ts
+++ b/src/personas/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { getArchetypeById, getArchetypeSubset, PERSONA_BUNDLES, ARCHETYPES } from './index';
+
+describe('getArchetypeById', () => {
+  it('finds an existing archetype', () => {
+    const result = getArchetypeById('happy-path');
+    expect(result).toBeDefined();
+    expect(result!.id).toBe('happy-path');
+  });
+
+  it('returns undefined for unknown id', () => {
+    expect(getArchetypeById('nonexistent')).toBeUndefined();
+  });
+});
+
+describe('getArchetypeSubset', () => {
+  it('returns correct subset', () => {
+    const result = getArchetypeSubset(['happy-path', 'mobile-first']);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('happy-path');
+    expect(result[1].id).toBe('mobile-first');
+  });
+
+  it('preserves order of input IDs', () => {
+    const result = getArchetypeSubset(['mobile-first', 'happy-path']);
+    expect(result[0].id).toBe('mobile-first');
+    expect(result[1].id).toBe('happy-path');
+  });
+
+  it('throws on unknown ID with helpful message', () => {
+    expect(() => getArchetypeSubset(['happy-path', 'bogus'])).toThrow('Unknown archetype "bogus"');
+    expect(() => getArchetypeSubset(['bogus'])).toThrow('Valid IDs:');
+  });
+});
+
+describe('PERSONA_BUNDLES', () => {
+  it('has correct counts', () => {
+    expect(PERSONA_BUNDLES.quick).toHaveLength(3);
+    expect(PERSONA_BUNDLES.standard).toHaveLength(5);
+    expect(PERSONA_BUNDLES.comprehensive).toHaveLength(8);
+    expect(PERSONA_BUNDLES.full).toHaveLength(10);
+  });
+
+  it('each bundle is a superset of the previous', () => {
+    const quick = new Set(PERSONA_BUNDLES.quick);
+    const standard = new Set(PERSONA_BUNDLES.standard);
+    const comprehensive = new Set(PERSONA_BUNDLES.comprehensive);
+    const full = new Set(PERSONA_BUNDLES.full);
+
+    for (const id of quick) expect(standard.has(id)).toBe(true);
+    for (const id of standard) expect(comprehensive.has(id)).toBe(true);
+    for (const id of comprehensive) expect(full.has(id)).toBe(true);
+  });
+
+  it('all IDs resolve to valid archetypes', () => {
+    const allIds = [
+      ...PERSONA_BUNDLES.quick,
+      ...PERSONA_BUNDLES.standard,
+      ...PERSONA_BUNDLES.comprehensive,
+      ...PERSONA_BUNDLES.full,
+    ];
+    const validIds = new Set(ARCHETYPES.map((a) => a.id));
+    for (const id of allIds) {
+      expect(validIds.has(id)).toBe(true);
+    }
+  });
+});

--- a/src/utils/costs.test.ts
+++ b/src/utils/costs.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { MODEL_PRICING, getPricing, CostTracker } from './costs';
+
+describe('MODEL_PRICING', () => {
+  it('has all 4 known models', () => {
+    expect(Object.keys(MODEL_PRICING)).toHaveLength(4);
+    expect(MODEL_PRICING['anthropic/claude-sonnet-4.6']).toBeDefined();
+    expect(MODEL_PRICING['google/gemini-2.0-flash-001']).toBeDefined();
+    expect(MODEL_PRICING['openai/gpt-4o-2024-11-20']).toBeDefined();
+    expect(MODEL_PRICING['anthropic/claude-opus-4.5']).toBeDefined();
+  });
+
+  it('all prices are positive', () => {
+    for (const [, pricing] of Object.entries(MODEL_PRICING)) {
+      expect(pricing.input).toBeGreaterThan(0);
+      expect(pricing.output).toBeGreaterThan(0);
+    }
+  });
+
+  it('output price >= input price for all models', () => {
+    for (const [, pricing] of Object.entries(MODEL_PRICING)) {
+      expect(pricing.output).toBeGreaterThanOrEqual(pricing.input);
+    }
+  });
+});
+
+describe('getPricing', () => {
+  it('returns exact match', () => {
+    const result = getPricing('anthropic/claude-sonnet-4.6');
+    expect(result).toEqual({ input: 3, output: 15 });
+  });
+
+  it('returns prefix match', () => {
+    const result = getPricing('anthropic/claude-sonnet-4.6:beta');
+    expect(result).toEqual({ input: 3, output: 15 });
+  });
+
+  it('returns fallback for unknown model', () => {
+    expect(getPricing('unknown/model-xyz')).toEqual({ input: 5, output: 15 });
+  });
+});
+
+describe('CostTracker', () => {
+  it('reports zero cost on fresh instance', () => {
+    const tracker = new CostTracker();
+    expect(tracker.totalCost()).toBe(0);
+  });
+
+  it('record accumulates cost', () => {
+    const tracker = new CostTracker();
+    tracker.record('Stage 2', 'anthropic/claude-sonnet-4.6', {
+      prompt: 1_000_000,
+      completion: 1_000_000,
+      total: 2_000_000,
+    });
+    // cost = (1M * 3 + 1M * 15) / 1M = 18
+    expect(tracker.totalCost()).toBe(18);
+  });
+
+  it('ignores undefined usage', () => {
+    const tracker = new CostTracker();
+    tracker.record('Stage 2', 'anthropic/claude-sonnet-4.6', undefined);
+    expect(tracker.totalCost()).toBe(0);
+  });
+
+  it('formatSummary returns empty array when no records', () => {
+    const tracker = new CostTracker();
+    expect(tracker.formatSummary()).toEqual([]);
+  });
+
+  it('formatSummary includes stage names and totals after recording', () => {
+    const tracker = new CostTracker();
+    tracker.record('Stage 2', 'anthropic/claude-sonnet-4.6', {
+      prompt: 100_000,
+      completion: 50_000,
+      total: 150_000,
+    });
+    const lines = tracker.formatSummary();
+    expect(lines.length).toBeGreaterThan(0);
+    const joined = lines.join('\n');
+    expect(joined).toContain('Stage 2');
+    expect(joined).toContain('Total');
+  });
+});
+
+describe('CostTracker.estimateDryRun', () => {
+  const screenshotModels = [
+    { id: 'anthropic/claude-sonnet-4.6', name: 'claude' },
+    { id: 'google/gemini-2.0-flash-001', name: 'gemini' },
+  ];
+  const videoModel = { id: 'google/gemini-2.0-flash-001', name: 'gemini' };
+  const synthesisModel = { id: 'anthropic/claude-opus-4.5', name: 'opus' };
+
+  it('returns lines', () => {
+    const lines = CostTracker.estimateDryRun(screenshotModels, videoModel, synthesisModel, 3, 2, false);
+    expect(lines.length).toBeGreaterThan(0);
+  });
+
+  it('contains stage names', () => {
+    const lines = CostTracker.estimateDryRun(screenshotModels, videoModel, synthesisModel, 3, 2, false);
+    const joined = lines.join('\n');
+    expect(joined).toContain('Stage 2');
+    expect(joined).toContain('Stage 2b');
+    expect(joined).toContain('Stage 3');
+  });
+
+  it('skipVideo produces "skipped" line', () => {
+    const lines = CostTracker.estimateDryRun(screenshotModels, videoModel, synthesisModel, 3, 2, true);
+    const joined = lines.join('\n');
+    expect(joined).toContain('skipped');
+  });
+});

--- a/src/utils/files.test.ts
+++ b/src/utils/files.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveArtifacts } from './files';
+
+describe('resolveArtifacts', () => {
+  const runDir = '/tmp/artifacts/run-2026-02-22T10-00';
+  const result = resolveArtifacts(runDir);
+
+  it('runId is basename of input', () => {
+    expect(result.runId).toBe('run-2026-02-22T10-00');
+  });
+
+  it('runDir is preserved', () => {
+    expect(result.runDir).toBe(runDir);
+  });
+
+  it('builds all 7 subdirectory paths', () => {
+    expect(result.videosDir).toBe(`${runDir}/videos`);
+    expect(result.screenshotsDir).toBe(`${runDir}/screenshots`);
+    expect(result.summariesDir).toBe(`${runDir}/summaries`);
+    expect(result.framesDir).toBe(`${runDir}/frames`);
+    expect(result.gridsDir).toBe(`${runDir}/grids`);
+    expect(result.diffsDir).toBe(`${runDir}/diffs`);
+    expect(result.reportsDir).toBe(`${runDir}/reports`);
+  });
+
+  it('returns all 9 fields', () => {
+    const keys = Object.keys(result);
+    expect(keys).toHaveLength(9);
+    expect(keys).toContain('runId');
+    expect(keys).toContain('runDir');
+    expect(keys).toContain('videosDir');
+    expect(keys).toContain('screenshotsDir');
+    expect(keys).toContain('summariesDir');
+    expect(keys).toContain('framesDir');
+    expect(keys).toContain('gridsDir');
+    expect(keys).toContain('diffsDir');
+    expect(keys).toContain('reportsDir');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "examples"]
+  "exclude": ["node_modules", "dist", "examples", "src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Install vitest and configure test infrastructure (`vitest.config.ts`, test scripts, tsconfig exclusion)
- Export 3 private functions (`parseArgs`, `validateConfig`, `redactApiKey`) for testability
- Add 6 test files covering all pure/testable functions: CLI arg parsing, config validation, API key redaction, persona archetypes & bundles, cost tracking & estimation, and file path resolution
- 72 tests, all passing

## Test plan
- [x] `npm test` — 72/72 pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — no `.test.*` files in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)